### PR TITLE
remove empty() call

### DIFF
--- a/livestamp.js
+++ b/livestamp.js
@@ -21,7 +21,7 @@
       var newData = $.extend({ }, { 'original': $el.contents() }, oldData);
       newData.moment = moment(timestamp);
 
-      $el.data('livestampdata', newData).empty();
+      $el.data('livestampdata', newData);
       $livestamps.push($el[0]);
     }
   },


### PR DESCRIPTION
This was emptying the element instead of using the logic in "change.livestamp" event listeners to handle not only updates but also initialization (e.g. for custom update animations).

I don't believe this will cause any significant regressions, since with polling the update() function is usually called relatively soon anyway, but it's worth testing.
