### PR TITLE
Fixed persistent memory leaks due to prevObject

### DIFF
--- a/livestamp.js
+++ b/livestamp.js
@@ -68,6 +68,7 @@
       });
 
       $livestamps = $livestamps.not(toRemove);
+      delete $livestamps.prevObject
     },
 
     pause: function() {


### PR DESCRIPTION
Since we keep the $livestamps object around any references will never be
freed unless specifically told to do so.  Filtering the elements with
the not() jQuery function causes the prevObject to be set, but
reassigning it appends the selected objects to the prevObject member of
$livestamps.  This causes the chain of prevObjects to continue to grow
unbounded on each invocation of the timer resulting in a memory leak.
This fix merely deletes the prevObject preventing the leak from
occurring.
