### PR TITLE
Sets the "From" date to compare with (instead of the current time)

### DIFF
--- a/livestamp.js
+++ b/livestamp.js
@@ -26,7 +26,7 @@
 
     timestamp = moment(timestamp);
     if ($.livestampTimeFrom !== undefined) {
-      timestamp.subtract(timestamp.diff(moment.unix($.livestampTimeFrom)));
+      timestamp.add(timestamp.diff(moment.unix($.livestampTimeFrom)));
     }
 
     if (moment.isMoment(timestamp) && !isNaN(+timestamp)) {

--- a/livestamp.js
+++ b/livestamp.js
@@ -25,6 +25,10 @@
       .removeData('livestamp');
 
     timestamp = moment(timestamp);
+    if ($.livestampTimeFrom !== undefined) {
+      timestamp.subtract(timestamp.diff(moment.unix($.livestampTimeFrom)));
+    }
+
     if (moment.isMoment(timestamp) && !isNaN(+timestamp)) {
       var newData = $.extend({ }, { 'original': $el.contents() }, oldData);
       newData.moment = moment(timestamp);

--- a/livestamp.js
+++ b/livestamp.js
@@ -26,7 +26,7 @@
 
     timestamp = moment(timestamp);
     if ($.livestampTimeFrom !== undefined) {
-      timestamp.add(timestamp.diff(moment.unix($.livestampTimeFrom)));
+        timestamp.subtract(moment.unix($.livestampTimeFrom).diff(moment()));
     }
 
     if (moment.isMoment(timestamp) && !isNaN(+timestamp)) {


### PR DESCRIPTION
This is a quick and dirty solution to the issue #39.

It takes the global (_ugghh... I know_) unix timestamp $.livestampTimeFrom and shifts the date accordingly. A basic implementation in PHP would be:

```
<script type="text/javascript">
$.livestampTimeFrom = <?=time()?>;
</script>
```

This is far from ideal as I haven't found an elegant solution to add a local parameter to livestamp, but it seems to work.
