### PR TITLE
Fix Deprecation Notice

### DIFF
--- a/livestamp.js
+++ b/livestamp.js
@@ -24,10 +24,10 @@
     $el.removeAttr('data-livestamp')
       .removeData('livestamp');
 
-    timestamp = moment(timestamp);
+    timestamp = moment(new Date(timestamp));
     if (moment.isMoment(timestamp) && !isNaN(+timestamp)) {
       var newData = $.extend({ }, { 'original': $el.contents() }, oldData);
-      newData.moment = moment(timestamp);
+      newData.moment = moment(new Date(timestamp));
 
       $el.data('livestampdata', newData).empty();
       $livestamps.push($el[0]);
@@ -91,7 +91,7 @@
     add: function($el, timestamp) {
       if (typeof timestamp == 'number')
         timestamp *= 1e3;
-      timestamp = moment(timestamp);
+      timestamp = moment(new Date(timestamp));
 
       if (moment.isMoment(timestamp) && !isNaN(+timestamp)) {
         $el.each(function() {


### PR DESCRIPTION
Turn `timestamp` into an actual Date object rather than a string.  Removes Deprecation Notice.

Fixes #25

Also, if you need help maintaining this project, I would love to contribute :)
